### PR TITLE
Fixed #include typo in go/GoInfluence.cpp

### DIFF
--- a/go/GoInfluence.cpp
+++ b/go/GoInfluence.cpp
@@ -8,7 +8,7 @@
 
 #include <vector>
 #include "SgNbIterator.h"
-#include "SgPointset.h"
+#include "SgPointSet.h"
 
 //----------------------------------------------------------------------------
 namespace {


### PR DESCRIPTION
I got this while trying to get the initial build to work correctly.